### PR TITLE
Scraper (should be) fixed! 

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -50,14 +50,20 @@ class ProductsController < ApplicationController
 
   def scrape
     authorize :product, :scrape?
+    user_id = current_user.id
 
-    unless params[:link].nil?
-      product_params = Scraper.validator(params[:link])
+    # old scraper that is fucked
+    # unless params[:link].nil?
+    #   product_params = Scraper.validator(params[:link])
+    #   product_params.each do |param|
+    #     # ScrapeJob.perform_later(param, current_user.id)
+    #     ScrapeJob.perform_later(param, user_id)
+    #   end
+    # end
 
-      product_params.each do |param|
-        ScrapeJob.perform_later(param, current_user.id)
-      end
-    end
+    # new scraper i really hope works
+##
+    HailMaryScraperJob.perform_later(params[:link], user_id) unless params[:link].nil?
     redirect_to private_profile_path
   end
 
@@ -65,7 +71,7 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
     authorize @product
     @product.destroy
-    redirect_to private_profile_path(current_user)
+    # redirect_to private_profile_path(current_user)
     flash[:alert] = "⚡️ #{@product.title} was removed from your store!"
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -72,7 +72,9 @@ class ProductsController < ApplicationController
     authorize @product
     @product.destroy
     # redirect_to private_profile_path(current_user)
-    flash[:alert] = "⚡️ #{@product.title} was removed from your store!"
+    ActionCable.server.broadcast "#{current_user.id}:product_flashes",
+      message: "<p><strong>#{@product.title}</strong> was removed from your store!</p>",
+      flash_color: "danger"
   end
 
   private

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,6 +5,9 @@ class ProfilesController < ApplicationController
     @user = current_user
     authorize :profile, :private_profile?
 
+    ## new scraper
+    # Scraper.single_job(params[:link], @user.id) unless params[:link].nil?
+
     @products = Product.where(user: @user)
 
     flash.now[:notice] = "👋 Hi #{@user.first_name}! Welcome to is your new store. Add some products to get started." if @user.products.empty?

--- a/app/javascript/plugins/api_refresh.js
+++ b/app/javascript/plugins/api_refresh.js
@@ -2,7 +2,7 @@ const card_container = document.getElementById('api-refresh');
 
 const apiFetch = () => {
   const user = document.querySelector('.user-info').id
-  fetch(`${location.origin}//api/v1/users/${user}/products`)
+  fetch(`${location.origin}/api/v1/users/${user}/products`)
   .then(response => response.json())
   .then((data) => {
     card_container.innerHTML = "";

--- a/app/jobs/hail_mary_scraper_job.rb
+++ b/app/jobs/hail_mary_scraper_job.rb
@@ -1,0 +1,7 @@
+class HailMaryScraperJob < ApplicationJob
+  queue_as :default
+
+  def perform(links, user_id)
+    Scraper.single_job(links, user_id)
+  end
+end

--- a/app/jobs/scrape_job.rb
+++ b/app/jobs/scrape_job.rb
@@ -9,25 +9,14 @@ class ScrapeJob < ApplicationJob
 
     if amazon_check
       product_params = Scraper.amazon_scraper(link)
-      user_exists = User.find_by_id(user_id).nil?
-      return if product_params.nil? || user_exists
+      return if product_params.nil?
 
       new_product = Product.new(product_params)
-      new_product.user_id = user_id
+      new_product.user_id = user_id # current_user
       new_product.remote_photo_url = product_params[:photo]
-      if new_product.save!
-        ActionCable.server.broadcast "#{user_id}:product_flashes",
-        message: "<p>🎉 <strong>#{new_product.title}</strong> successfully added to your store!</p>",
-        flash_color: "purple"
-        # p "#{new_product.title} added to #{user.first_name}"
-      # else
-      end
+      new_product.save!
     else
-      sleep(1) # fix this so it doesn't load on home page. (using 'current_page?' ?)
-      ActionCable.server.broadcast "#{user_id}:product_flashes",
-      message: "<p>😢 Uhoh! This is embarrassing... We can't automatically add products from <strong>#{seller}</strong> yet. Please add manually.</p>",
-      flash_color: "danger"
-      # p "Unable to auto-generate a link from #{seller}."
+      p "Sorry. Unable to auto-generate a link from #{seller}."
     end
   end
 end

--- a/app/views/profiles/public_profile.html.erb
+++ b/app/views/profiles/public_profile.html.erb
@@ -1,7 +1,3 @@
-<% content_for :meta_title, "#{@user.first_name} #{@user.last_name} store is on #{DEFAULT_META["meta_product_name"]}" %>
-<% content_for :meta_description, @user.description %>
-<% content_for :meta_image, cl_image_path(@user.photo) %>
-
 <div class="container profile-flex nav-padding">
 
     <div class="user-info user-info-left">

--- a/test/jobs/hail_mary_scraper_job_test.rb
+++ b/test/jobs/hail_mary_scraper_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class HailMaryScraperJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Ok, so we shouldn't get any more 503 errors from the scraper — because we now pass some headers which make us look a little bit more like a real user. 

I've turned each individual scrape job into one massive job which does all the products in one go. As our profile page refreshes every second or so, this works well. 

WE CANNOT SCRAPE THE GAFF TAPE!!!! It's a discontinued product, so there's heaps of missing info... let's remove this from the html in peter's page for tomorrow. 